### PR TITLE
Implement event detail page with state-based UI + MUI

### DIFF
--- a/app/events/[eventId]/cook/page.tsx
+++ b/app/events/[eventId]/cook/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import Sidebar from "@/components/appLayout";
+
+const CookPage: React.FC = () => {
+    const params = useParams();
+    const eventId = params?.eventId as string;
+
+    return (
+        <div style={{ display: "flex", minHeight: "100vh", backgroundColor: "#fff"}}>
+            <Sidebar />    
+            <main style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center"}}>
+                <p style={{ color: "*999", fontSize: 16}}>Cooking interface for event {eventId}, this is placeholder</p>
+            </main>
+        </div>
+    );
+};
+
+export default CookPage;

--- a/app/events/[eventId]/page.tsx
+++ b/app/events/[eventId]/page.tsx
@@ -5,7 +5,8 @@ import { useParams, useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import Sidebar, { UserAvatar } from "@/components/appLayout";
-import { Button, Spin, Avatar, message, Tooltip } from "antd";
+import { Spin } from "antd";
+import { Button, ButtonGroup, Avatar, AvatarGroup, Chip, Tooltip } from "@mui/material";
 
 // ---------------------------------------------------------------------------
 // ICON COMPONENT
@@ -22,7 +23,6 @@ const Icon = ({ name, size = 18 }: { name: string; size?: number }) => (
 interface Participant {
   id: string;
   username: string;
-  avatarUrl?: string;
 }
 
 interface CookingEvent {
@@ -70,14 +70,14 @@ async function fetchEventData(
     { Authorization: `Bearer ${token}` }
   );
   setEvent(data);
-  setIsRegistered(data.participants.some((p) => p.id === userId));
+  setIsRegistered(data.participants.some((p) => String(p.id) === userId));
 }
 
 // ---------------------------------------------------------------------------
 // BANNER
 // ---------------------------------------------------------------------------
 function renderBanner(emojiString?: string): React.ReactNode[] {
-  const emojis = emojiString ? [...emojiString].filter(c => c.trim()) : ["🍳", "🥘", "🍽️"];
+  const emojis = emojiString ? (emojiString.match(/\p{Emoji_Presentation}|\p{Emoji}\uFE0F/gu) || ["🍳", "🥘", "🍽️"]): ["🍳", "🥘", "🍽️"];
   const COLS = 29;
   const ROWS = 3;
   const items: React.ReactNode[] = [];
@@ -112,27 +112,22 @@ async function registerForEvent(
   setEvent: (e: CookingEvent) => void,
 ): Promise<void> {
   if (!token) {
-    message.warning("Please log in first.");
     router.push("/login");
     return;
   }
   setRegistering(true);
   try {
-    await apiService.post(`/events/${eventId}/participants`, {});
+    await apiService.post(`/events/${eventId}/participants`, {}, {Authorization: `Bearer ${token}` });
     setIsRegistered(true);
     const updated = await apiService.get<CookingEvent>(
       `/events/${eventId}`,
       { Authorization: `Bearer ${token}` }
     );
     setEvent(updated);
-    message.success(`Registered! ${updated.participants.length} participants so far.`);
   } catch (error) {
     if (error instanceof Error) {
       if (error.message.includes("409")) {
-        message.info("Already registered.");
         setIsRegistered(true);
-      } else {
-        message.error(`Registration failed: ${error.message}`);
       }
     }
   } finally {
@@ -155,9 +150,8 @@ async function cancelRegistration(
       { Authorization: `Bearer ${token}` }
     );
     setEvent(updated);
-    message.success("Registration cancelled.");
   } catch (error) {
-    if (error instanceof Error) message.error(`Could not cancel: ${error.message}`);
+    // Error handling
   }
 }
 
@@ -166,29 +160,19 @@ async function cancelRegistration(
 // ---------------------------------------------------------------------------
 const ParticipantList = ({ participants }: { participants: Participant[] }) => (
   <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
-    <Avatar.Group max={{ count: 3 }} size={32}>
-      {participants.map((p) => (
-        <Tooltip key={p.id} title={p.username}>
-          <Avatar src={p.avatarUrl} style={{ backgroundColor: "#4a7c59" }}>
-            {getInitials(p.username)}
-          </Avatar>
-        </Tooltip>
-      ))}
-    </Avatar.Group>
-    {participants.length === 0 && (
+    {participants.length > 0 ? (
+      <AvatarGroup max={3} sx={{ "& .MuiAvatar-root": { width: 32, height: 32, fontSize: 13, backgroundColor: "#4a7c59"} }}>
+        {participants.map((p) => (
+          <Tooltip key={p.id} title={p.username} arrow>
+            <Avatar sx={{ bgcolor: "#4a7c59" }}>
+              {getInitials(p.username)}
+            </Avatar>
+          </Tooltip>
+        ))}
+      </AvatarGroup>
+    ) : (
       <span style={{ color: "#999", fontSize: 13 }}>No participants yet</span>
     )}
-  </div>
-);
-
-
-const RegistrationConfirmation = ({ count, onCancel }: { count: number; onCancel: () => void }) => (
-  <div style={{ backgroundColor: "#f0faf3", border: "1px solid #b2dfdb", borderRadius: 8, padding: "10px 16px", fontSize: 14, color: "#2e7d32", marginBottom: 20, display: "flex", alignItems: "center" }}>
-    <Icon name="check_circle" />
-    <span style={{ marginLeft: 8 }}>You&apos;re registered! Total participants: {count}</span>
-    <Button type="link" danger size="small" onClick={onCancel} style={{ marginLeft: 12 }}>
-      Cancel registration
-    </Button>
   </div>
 );
 
@@ -216,109 +200,30 @@ const NotFoundScreen = ({ onBack }: { onBack: () => void }) => (
 );
 
 
-const StatusBadge = ({ state }: { state: CookingEvent["state"] }) => (
-  <div style={{ display: "inline-block", backgroundColor: "#e8f5e9", border: "1px solid #a5d6a7", borderRadius: 20, padding: "4px 14px", fontSize: 13, fontWeight: 600, color: "#2d4a38" }}>
-    {state === "ONGOING" ? "🟢 Live now" : state === "FINISHED" ? "⚫ Ended" : "🔵 Upcoming"}
-  </div>
-);
+const StatusBadge = ({ state }: { state: CookingEvent["state"] }) => {
+  const config = state === "ONGOING"
+    ? { label: "Live now", color: "#2e7d32", bg: "#e8f5e9", border: "#a5d6aa7", icon: "radio_button_checked"}
+    : state === "FINISHED"
+    ? { label: "Ended", color: "#555", bg: "#f5f5f5", border: "#ccc", icon: "check_circle" }
+    : { label: "Upcoming", color: "#1565c0", bg: "#e3f2fd", border: "#90caf9", icon: "schedule" };
 
-const ParticipateButton = ({
-  disabled,
-  tooltip,
-  onClick,
-}: {
-  disabled: boolean;
-  tooltip: string;
-  onClick: () => void;
-}) => (
-  <Tooltip title={disabled ? tooltip : ""}>
-    <Button
-      type="primary"
-      icon={<Icon name="play_circle" />}
-      onClick={onClick}
-      disabled={disabled}
-      style={{
-        backgroundColor: disabled ? "#ccc" : "#4a7c59",
-        borderColor: disabled ? "#ccc" : "#4a7c59",
-        color: disabled ? "#888" : "#fff",
+  return (
+    <Chip
+      icon={<span className="material-symbols-rounded" style={{ fontSize: 16, color: config.color }}>{config.icon}</span>}
+      label={config.label}
+      variant="outlined"
+      sx={{
+        backgroundColor: config.bg,
+        borderColor: config.border,
+        color: config.color,
         fontWeight: 600,
-        height: 44,
-        paddingInline: 20,
-        borderRadius: 22,
-        fontSize: 14,
+        fontSize: 13,
+        height: 32,
+        alignSelf: "flex-start",
       }}
-    >
-      Participate
-    </Button>
-  </Tooltip>
-);
-
-function getRegisterTooltip(isEnded: boolean, isStarted: boolean, isRegistered: boolean): string {
-  if (isEnded) return "Event has ended";
-  if (isStarted) return "Registration closed";
-  if (isRegistered) return "Already registered";
-  return "";
-}
-
-const RegisterButton = ({
-  disabled,
-  loading,
-  isStarted,
-  isRegistered,
-  isEnded,
-  onRegister,
-  onCancel,
-}: {
-  disabled: boolean;
-  loading: boolean;
-  isStarted: boolean;
-  isRegistered: boolean;
-  isEnded: boolean;
-  onRegister: () => void;
-  onCancel: () => void;
-}) => (
-  <div style={{ display: "flex" }}>
-    <Tooltip title={getRegisterTooltip(isEnded, isStarted, isRegistered)}>
-      <Button
-        type="primary"
-        icon={<span className="material-symbols-rounded" style={{ fontSize: 18, display: "flex", alignItems: "center" }}>person_add</span>}
-        onClick={onRegister}
-        loading={loading}
-        disabled={disabled}
-        style={{
-          backgroundColor: disabled ? "#ccc" : "#4a7c59",
-          borderColor: disabled ? "#ccc" : "#4a7c59",
-          color: disabled ? "#888" : "#fff",
-          fontWeight: 600,
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          height: 44,
-          padding: "0 20px",
-          borderRadius: "22px 0 0 22px",
-          fontSize: 14,
-        }}
-      >
-        Register
-      </Button>
-    </Tooltip>
-    <Tooltip title={isRegistered ? "Cancel registration" : ""}>
-      <Button
-        icon={<span className="material-symbols-rounded" style={{ fontSize: 18 }}>expand_more</span>}
-        onClick={isRegistered ? onCancel : undefined}
-        disabled={isStarted}
-        style={{
-          backgroundColor: isStarted ? "#ccc" : "#4a7c59",
-          borderColor: isStarted ? "#ccc" : "#4a7c59",
-          color: isStarted ? "#888" : "#fff",
-          height: 44,
-          borderRadius: "0 22px 22px 0",
-          marginLeft: 1,
-        }}
-      />
-    </Tooltip>
-  </div>
-);
+    />
+  );
+};
 
 // ---------------------------------------------------------------------------
 // MAIN COMPONENT
@@ -344,7 +249,6 @@ const EventDetailPage: React.FC = () => {
     if (!eventId) return;
     setLoading(true);
     fetchEventData(apiService, eventId, token, userId, setEvent, setIsRegistered)
-      .catch((err) => message.error(`Could not load event: ${err.message}`))
       .finally(() => setLoading(false));
   }, [eventId, apiService, userId, token]);
 
@@ -369,9 +273,6 @@ const EventDetailPage: React.FC = () => {
   const isFinished = event.state === "FINISHED";
   const durationMinutes = Math.round((new Date(event.endDatetime).getTime() - new Date(event.startDatetime).getTime()) / 60000);
   
-  const registerDisabled = !isUpcoming || isRegistered;
-  // const participateDisabled = !isOngoing || !isRegistered;
-
   return (
     <div style={{ display: "flex", minHeight: "100vh", backgroundColor: "#fff" }}>
       <Sidebar />
@@ -379,8 +280,8 @@ const EventDetailPage: React.FC = () => {
 
         {/* PAGE HEADING */}
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0 32px", height: 72 }}>
-          <h1 style={{ fontSize: 36, fontWeight: 600, margin: 0, color: "#1a1a1a" }}>
-            Event Details
+          <h1 style={{ fontSize: 16, fontWeight: 600, margin: 0, color: "#1a1a1a" }}>
+            {event.title}
           </h1>
           <UserAvatar size={40} />
         </div>
@@ -392,7 +293,6 @@ const EventDetailPage: React.FC = () => {
 
         {/* CONTENT */}
         <div style={{ padding: "24px 48px 40px" }}>
-          <h1 style={{ fontSize: 22, fontWeight: 700, margin: "0 0 6px", color: "#1a1a1a" }}>{event.title}</h1>
 
           {/* TWO COLUMNS */}
           <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 24, alignItems: "flex-start" }}>
@@ -440,25 +340,60 @@ const EventDetailPage: React.FC = () => {
 
           {/* STATE: UPCOMING */}
           {isUpcoming && (
-            <>
-              {/* Registration confirmation */}
-              {isRegistered && (
-                <RegistrationConfirmation count={event.participants.length} onCancel={handleCancel} />
-              )}
-              {/* BUTTONS */}
-              <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 40, paddingRight: 100 }}>
-                <RegisterButton
-                  disabled={registerDisabled}
-                  loading={registering}
-                  isStarted={false}
-                  isRegistered={isRegistered}
-                  isEnded={false}
-                  onRegister={handleRegister}
-                  onCancel={handleCancel}
-                />
-                <ParticipateButton disabled={true} tooltip="Event has not started yet" onClick={handleParticipate} />
-              </div>
-            </>
+            <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 40, paddingRight: 100 }}>
+              {/* Split Button: Register + Cancel */}
+              <ButtonGroup variant="contained" disableElevation style={{ borderRadius: 22, overflow: "hidden" }}>
+                <Button
+                  startIcon={<span className="material-symbols-rounded" style={{ fontSize: 18 }}>person_add</span>}
+                  onClick={handleRegister}
+                  disabled={isRegistered || registering}
+                  style={{
+                    backgroundColor: isRegistered ? "#888" : "#4a7c59",
+                    textTransform: "none",
+                    fontWeight: 600,
+                    height: 44,
+                    paddingLeft: 20,
+                    paddingRight: 20,
+                    borderRadius: "22px 0 0 22px",
+                  }}
+                >
+                  {isRegistered ? "Registered" : "Register"}
+                </Button>
+                <Button
+                  onClick={handleCancel}
+                  disabled={!isRegistered}
+                  style={{
+                    backgroundColor: isRegistered ? "#4a7c59" : "#ccc",
+                    minWidth: 40,
+                    height: 44,
+                    borderRadius: "0 22px 22px 0",
+                    borderLeft: "1px solid rgba(255,255,255,0.3)",
+                  }}
+                >
+                  <span className="material-symbols-rounded" style={{ fontSize: 18 }}>
+                    {isRegistered ? "close" : "expand_more"}
+                  </span>
+                </Button>
+              </ButtonGroup>
+
+              {/* Participate (disabled when UPCOMING) */}
+              <Button
+                variant="contained"
+                startIcon={<span className="material-symbols-rounded" style={{ fontSize: 18 }}>play_circle</span>}
+                disabled={true}
+                style={{
+                  backgroundColor: "#ccc",
+                  textTransform: "none",
+                  fontWeight: 600,
+                  height: 44,
+                  borderRadius: 22,
+                  paddingLeft: 20,
+                  paddingRight: 20,
+                }}
+              >
+                Participate
+              </Button>
+            </div>
           )}
 
           {/* STATE: ONGOING */}
@@ -476,7 +411,22 @@ const EventDetailPage: React.FC = () => {
                     </p>
                   </div>
                   <div style={{ display: "flex", justifyContent: "flex-end", paddingRight: 100}}>
-                    <ParticipateButton disabled={false} tooltip="" onClick={handleParticipate} />
+                    <Button
+                      variant="contained"
+                      startIcon={<span className="material-symbols-rounded" style={{ fontSize: 18 }}>play_circle</span>}
+                      onClick={handleParticipate}
+                      style={{
+                        backgroundColor: "#4a7c59",
+                        textTransform: "none",
+                        fontWeight: 600,
+                        height: 44,
+                        borderRadius: 22,
+                        paddingLeft: 20,
+                        paddingRight: 20,
+                      }}
+                    >
+                      Participate
+                    </Button>
                   </div>
                 </div>
               ) : (
@@ -496,18 +446,18 @@ const EventDetailPage: React.FC = () => {
           {/* STATE: FINISHED */}
           {isFinished && (
             <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 40, paddingRight: 100}}>
-              <Button 
-                type="primary"
-                icon={<Icon name="emoji_events" />}
+              <Button
+                variant="contained"
+                startIcon={<span className="material-symbols-rounded" style={{ fontSize: 18 }}>emoji_events</span>}
                 onClick={() => router.push(`/events/${eventId}/cook`)}
                 style={{
                   backgroundColor: "#4a7c59",
-                  borderColor: "#4a7c59",
+                  textTransform: "none",
                   fontWeight: 600,
                   height: 44,
-                  paddingInline: 20,
                   borderRadius: 22,
-                  fontSize: 14,
+                  paddingLeft: 20,
+                  paddingRight: 20,
                 }}
               >
                 View Results

--- a/app/events/[eventId]/page.tsx
+++ b/app/events/[eventId]/page.tsx
@@ -28,42 +28,18 @@ interface Participant {
 interface CookingEvent {
   id: string;
   title: string;
-  description: string;
-  bannerEmojis?: string[];
+  emojis: string;
   ingredients: string[];
-  startTime: string;
-  endTime: string;
-  durationMinutes: number;
+  startDatetime: string;
+  endDatetime: string;
   participants: Participant[];
-  status: "UPCOMING" | "ACTIVE" | "ENDED";
+  state: "UPCOMING" | "ONGOING" | "FINISHED";
 }
 
+
 // ---------------------------------------------------------------------------
-// MOCK DATA
+// HELPERS
 // ---------------------------------------------------------------------------
-const USE_MOCK = true;
-
-const MOCK_EVENT: CookingEvent = {
-  id: "mock-event-1",
-  title: "Spring Cooking Event",
-  description: "Get ready for spring with this challenging cooking event!",
-  bannerEmojis: ["🍋", "🥒", "🍝"],
-  ingredients: ["Spaghetti", "Cucumbers", "Lemon"],
-  startTime: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-  endTime: new Date(Date.now() + 1000 * 60 * 120).toISOString(),
-  durationMinutes: 60,
-  participants: [
-    { id: "user-1", username: "alice aber" },
-    { id: "user-2", username: "bob trump" },
-    { id: "user-3", username: "charlie clinton" },
-    { id: "user-4", username: "diana stone" },
-  ],
-  status: "UPCOMING",
-};
-
-
-
-
 const getInitials = (name: string): string =>
   name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
 
@@ -78,8 +54,9 @@ function formatEventTime(startIso: string, endIso: string): string {
   return `${dayName} ${day} ${month}, ${s} - ${e}`;
 }
 
-
-
+// ---------------------------------------------------------------------------
+// DATA FETCHING
+// ---------------------------------------------------------------------------
 async function fetchEventData(
   apiService: ReturnType<typeof useApi>,
   eventId: string,
@@ -88,12 +65,6 @@ async function fetchEventData(
   setEvent: (e: CookingEvent) => void,
   setIsRegistered: (v: boolean) => void,
 ): Promise<void> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 500));
-    setEvent(MOCK_EVENT);
-    setIsRegistered(MOCK_EVENT.participants.some((p) => p.id === userId));
-    return;
-  }
   const data = await apiService.get<CookingEvent>(
     `/events/${eventId}`,
     { Authorization: `Bearer ${token}` }
@@ -102,10 +73,11 @@ async function fetchEventData(
   setIsRegistered(data.participants.some((p) => p.id === userId));
 }
 
-
-
-function renderBanner(bannerEmojis?: string[]): React.ReactNode[] {
-  const emojis = bannerEmojis ?? ["🍋", "🥒", "🍝"];
+// ---------------------------------------------------------------------------
+// BANNER
+// ---------------------------------------------------------------------------
+function renderBanner(emojiString?: string): React.ReactNode[] {
+  const emojis = emojiString ? [...emojiString].filter(c => c.trim()) : ["🍳", "🥘", "🍽️"];
   const COLS = 29;
   const ROWS = 3;
   const items: React.ReactNode[] = [];
@@ -127,6 +99,9 @@ function renderBanner(bannerEmojis?: string[]): React.ReactNode[] {
   return items;
 }
 
+// ---------------------------------------------------------------------------
+// REGISTER / CANCEL
+// ---------------------------------------------------------------------------
 async function registerForEvent(
   apiService: ReturnType<typeof useApi>,
   eventId: string,
@@ -136,11 +111,6 @@ async function registerForEvent(
   setIsRegistered: (v: boolean) => void,
   setEvent: (e: CookingEvent) => void,
 ): Promise<void> {
-  if (USE_MOCK) {
-    setIsRegistered(true);
-    message.success("Registered! (mock mode)");
-    return;
-  }
   if (!token) {
     message.warning("Please log in first.");
     router.push("/login");
@@ -177,11 +147,6 @@ async function cancelRegistration(
   setIsRegistered: (v: boolean) => void,
   setEvent: (e: CookingEvent) => void,
 ): Promise<void> {
-  if (USE_MOCK) {
-    setIsRegistered(false);
-    message.success("Registration cancelled.");
-    return;
-  }
   try {
     await apiService.delete<void>(`/events/${eventId}/participants`);
     setIsRegistered(false);
@@ -196,7 +161,9 @@ async function cancelRegistration(
   }
 }
 
-
+// ---------------------------------------------------------------------------
+// SUB-COMPONENTS
+// ---------------------------------------------------------------------------
 const ParticipantList = ({ participants }: { participants: Participant[] }) => (
   <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
     <Avatar.Group max={{ count: 3 }} size={32}>
@@ -249,20 +216,22 @@ const NotFoundScreen = ({ onBack }: { onBack: () => void }) => (
 );
 
 
-const StatusBadge = ({ status }: { status: CookingEvent["status"] }) => (
+const StatusBadge = ({ state }: { state: CookingEvent["state"] }) => (
   <div style={{ display: "inline-block", backgroundColor: "#e8f5e9", border: "1px solid #a5d6a7", borderRadius: 20, padding: "4px 14px", fontSize: 13, fontWeight: 600, color: "#2d4a38" }}>
-    {status === "ACTIVE" ? "🟢 Live now" : "⚫ Ended"}
+    {state === "ONGOING" ? "🟢 Live now" : state === "FINISHED" ? "⚫ Ended" : "🔵 Upcoming"}
   </div>
 );
 
 const ParticipateButton = ({
   disabled,
+  tooltip,
   onClick,
 }: {
   disabled: boolean;
+  tooltip: string;
   onClick: () => void;
 }) => (
-  <Tooltip title={disabled ? "Register first and wait for event to start" : ""}>
+  <Tooltip title={disabled ? tooltip : ""}>
     <Button
       type="primary"
       icon={<Icon name="play_circle" />}
@@ -351,8 +320,9 @@ const RegisterButton = ({
   </div>
 );
 
-// COMPONENT 
-
+// ---------------------------------------------------------------------------
+// MAIN COMPONENT
+// ---------------------------------------------------------------------------
 const EventDetailPage: React.FC = () => {
   const params = useParams();
   const eventId = params?.eventId as string;
@@ -393,10 +363,14 @@ const EventDetailPage: React.FC = () => {
   if (loading) return <LoadingScreen />;
   if (!event) return <NotFoundScreen onBack={() => router.back()} />;
 
-  const isStarted = new Date() >= new Date(event.startTime);
-  const isEnded = new Date() >= new Date(event.endTime);
-  const registerDisabled = isStarted || isRegistered || isEnded;
-  const participateDisabled = !isStarted || !isRegistered;
+  // obtained states
+  const isUpcoming = event.state === "UPCOMING";
+  const isOngoing = event.state === "ONGOING";
+  const isFinished = event.state === "FINISHED";
+  const durationMinutes = Math.round((new Date(event.endDatetime).getTime() - new Date(event.startDatetime).getTime()) / 60000);
+  
+  const registerDisabled = !isUpcoming || isRegistered;
+  // const participateDisabled = !isOngoing || !isRegistered;
 
   return (
     <div style={{ display: "flex", minHeight: "100vh", backgroundColor: "#fff" }}>
@@ -413,13 +387,12 @@ const EventDetailPage: React.FC = () => {
 
         {/* BANNER */}
         <div style={{ position: "relative", height: 280, backgroundColor: "#f0f5f1", overflow: "hidden" }}>
-          {renderBanner(event.bannerEmojis)}
+          {renderBanner(event.emojis)}
         </div>
 
         {/* CONTENT */}
         <div style={{ padding: "24px 48px 40px" }}>
           <h1 style={{ fontSize: 22, fontWeight: 700, margin: "0 0 6px", color: "#1a1a1a" }}>{event.title}</h1>
-          <p style={{ fontSize: 14, color: "#666", margin: "0 0 28px" }}>{event.description}</p>
 
           {/* TWO COLUMNS */}
           <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 24, alignItems: "flex-start" }}>
@@ -440,7 +413,7 @@ const EventDetailPage: React.FC = () => {
                 <Icon name="event" />
                 <div>
                   <div style={{ fontSize: 13, fontWeight: 700, color: "#1a1a1a" }}>Time</div>
-                  <div style={{ fontSize: 13, color: "#444" }}>{formatEventTime(event.startTime, event.endTime)}</div>
+                  <div style={{ fontSize: 13, color: "#444" }}>{formatEventTime(event.startDatetime, event.endDatetime)}</div>
                 </div>
               </div>
 
@@ -448,7 +421,7 @@ const EventDetailPage: React.FC = () => {
                 <Icon name="schedule" />
                 <div>
                   <div style={{ fontSize: 13, fontWeight: 700, color: "#1a1a1a" }}>Duration</div>
-                  <div style={{ fontSize: 13, color: "#444" }}>{event.durationMinutes}min</div>
+                  <div style={{ fontSize: 13, color: "#444" }}>{durationMinutes}min</div>
                 </div>
               </div>
 
@@ -460,28 +433,88 @@ const EventDetailPage: React.FC = () => {
                 </div>
               </div>
 
-              {isStarted && <StatusBadge status={event.status} />}
+              <StatusBadge state={event.state} />
             </div>
           </div>
+          
 
-          {/* Registration confirmation */}
-          {isRegistered && !isStarted && (
-            <RegistrationConfirmation count={event.participants.length} onCancel={handleCancel} />
+          {/* STATE: UPCOMING */}
+          {isUpcoming && (
+            <>
+              {/* Registration confirmation */}
+              {isRegistered && (
+                <RegistrationConfirmation count={event.participants.length} onCancel={handleCancel} />
+              )}
+              {/* BUTTONS */}
+              <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 40, paddingRight: 100 }}>
+                <RegisterButton
+                  disabled={registerDisabled}
+                  loading={registering}
+                  isStarted={false}
+                  isRegistered={isRegistered}
+                  isEnded={false}
+                  onRegister={handleRegister}
+                  onCancel={handleCancel}
+                />
+                <ParticipateButton disabled={true} tooltip="Event has not started yet" onClick={handleParticipate} />
+              </div>
+            </>
           )}
 
-          {/* BUTTONS */}
-          <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 40, paddingRight: 100 }}>
-            <RegisterButton
-              disabled={registerDisabled}
-              loading={registering}
-              isStarted={isStarted}
-              isRegistered={isRegistered}
-              isEnded={isEnded}
-              onRegister={handleRegister}
-              onCancel={handleCancel}
-            />
-            <ParticipateButton disabled={participateDisabled} onClick={handleParticipate} />
-          </div>
+          {/* STATE: ONGOING */}
+          {isOngoing && (
+            <>
+              {isRegistered ? (
+                <div style={{ marginTop: 24 }}>
+                  <div style={{ backgroundColor: "#f0faf3", border: "1px solid #b2dfdb", borderRadius: 8, padding: "16px 20px", marginBottom: 20}}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8}}>
+                      <Icon name="restaurant" size={20} />
+                      <span style={{ fontWeight: 600, fontSize: 15, color: "#2e7d32"}}>The event is live!</span>
+                    </div>
+                    <p style={{ fontSize: 14, color: "#444", margin: 0}}>
+                      Click &quot;Participate&quot; to enter the cooking interface.
+                    </p>
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "flex-end", paddingRight: 100}}>
+                    <ParticipateButton disabled={false} tooltip="" onClick={handleParticipate} />
+                  </div>
+                </div>
+              ) : (
+                <div style={{ backgroundColor: "#fff8e1", border: "1px solid #ffe082", borderRadius: 8, padding: "16px 20px", marginTop: 24}}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8}}>
+                    <Icon name="lock" size={20} />
+                    <span style={{ fontWeight: 600, fontSize: 15, color: "#f57f17"}}>Registration closed</span>
+                  </div>
+                  <p style={{ fontSize: 14, color: "#666", margin: "8px 0 0"}}>
+                    This event has already started. Only registered participants can access the cooking interface.
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* STATE: FINISHED */}
+          {isFinished && (
+            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 40, paddingRight: 100}}>
+              <Button 
+                type="primary"
+                icon={<Icon name="emoji_events" />}
+                onClick={() => router.push(`/events/${eventId}/cook`)}
+                style={{
+                  backgroundColor: "#4a7c59",
+                  borderColor: "#4a7c59",
+                  fontWeight: 600,
+                  height: 44,
+                  paddingInline: 20,
+                  borderRadius: 22,
+                  fontSize: 14,
+                }}
+              >
+                View Results
+              </Button>
+            </div>
+          )}
+
         </div>
       </main>
     </div>


### PR DESCRIPTION
- Event detail page shows different UI based on event state (UPCOMING, ONGOING, FINISHED)
- UPCOMING: MUI split button for register/cancel registration, disabled Participate button
- ONGOING: registered users see Participate button, others see "Registration closed" warning (#33)
- FINISHED: View Results button navigates to /events/{eventId}/cook (this is the cooking interface) (#26) 
- Added placeholder cook page


closes #26  , #33 
