### PR TITLE
Adds badge UI, leaderboard page and event auto-refresh

### DIFF
--- a/app/components/Badge.tsx
+++ b/app/components/Badge.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from "react";
+import { Box, Tooltip } from "@mui/material";
+import { Badge as BadgeType } from "@/types/badge";
+
+/**
+ * Small pill showing an emoji + tier name. Used next to usernames and
+ * inside the badge showcase. `locked` greys it out (used for tiers the
+ * user has not yet unlocked).
+ */
+export const BadgeChip: React.FC<{
+  emoji: string;
+  name: string;
+  description?: string;
+  locked?: boolean;
+  current?: boolean;
+  size?: "small" | "medium";
+}> = ({ emoji, name, description, locked = false, current = false, size = "medium" }) => {
+  const fontSize = size === "small" ? 12 : 14;
+  const padX = size === "small" ? 1 : 1.25;
+
+  const chip = (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.5,
+        px: padX,
+        py: 0.25,
+        borderRadius: "999px",
+        backgroundColor: locked ? "#f1f1f1" : current ? "#dcefd5" : "#f5f7f1",
+        color: locked ? "#9aa0a6" : "#485F23",
+        border: current ? "1px solid #485F23" : "1px solid transparent",
+        fontSize,
+        fontWeight: current ? 700 : 500,
+        whiteSpace: "nowrap",
+        opacity: locked ? 0.6 : 1,
+      }}
+    >
+      <span>{emoji}</span>
+      <span>{name}</span>
+    </Box>
+  );
+
+  if (description) {
+    return <Tooltip title={description} arrow>{chip}</Tooltip>;
+  }
+  return chip;
+};
+
+/**
+ * Renders all tier badges for a user. Locked ones are greyed and show the
+ * required win count, the most dominant unlocked one is highlighted.
+ */
+export const BadgeShowcase: React.FC<{ badges: BadgeType[]; showDescriptions?: boolean }> = ({
+  badges,
+  showDescriptions = true,
+}) => {
+  if (!badges || badges.length === 0) {
+    return <Box sx={{ color: "#888", fontSize: 14 }}>No badges yet — go win some events!</Box>;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+      {badges.map((b) => (
+        <BadgeChip
+          key={b.code}
+          emoji={b.emoji}
+          name={b.displayName}
+          description={
+            showDescriptions
+              ? b.unlocked
+                ? b.description
+                : `${b.description} (Win ${b.requiredWins} event${b.requiredWins === 1 ? "" : "s"} to unlock)`
+              : undefined
+          }
+          locked={!b.unlocked}
+          current={b.current}
+        />
+      ))}
+    </Box>
+  );
+};

--- a/app/components/appLayout.tsx
+++ b/app/components/appLayout.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { Avatar as AntAvatar } from "antd";
 import { Drawer, Box, ListItemButton, ListItemIcon, BottomNavigation, BottomNavigationAction } from "@mui/material";
-import { RestaurantMenuRounded, HomeRounded, HomeOutlined, LibraryBooksRounded, LibraryBooksOutlined } from "@mui/icons-material";
+import { RestaurantMenuRounded, HomeRounded, HomeOutlined, LibraryBooksRounded, LibraryBooksOutlined, EmojiEventsRounded, EmojiEventsOutlined } from "@mui/icons-material";
 import useWindowSize from "@/hooks/useWndowSize";
 
 
@@ -26,6 +26,7 @@ const Sidebar: React.FC = () => {
       label: "Events"
     },
     { key: "cookbook", path: "/cookbook", inactiveIcon: <LibraryBooksOutlined style={{ fontSize: 22 }} />, activeIcon: <LibraryBooksRounded style={{ fontSize: 22 }} />, label: "Library" },
+    { key: "leaderboard", path: "/leaderboard", inactiveIcon: <EmojiEventsOutlined style={{ fontSize: 22 }} />, activeIcon: <EmojiEventsRounded style={{ fontSize: 22 }} />, label: "Leaderboard" },
   ];
 
   const activeIndex = Math.max(

--- a/app/events/overview/page.tsx
+++ b/app/events/overview/page.tsx
@@ -27,7 +27,7 @@ interface CookingEvent {
     state: "UPCOMING" | "ONGOING" | "FINISHED";
 }
 
-
+const REFRESH_MS = 15_000;
 
 const EventsPage: React.FC = () => {
     const router = useRouter();
@@ -41,12 +41,28 @@ const EventsPage: React.FC = () => {
 
     useEffect(() => {
         if (!token) { setLoading(false); return; }
-        setLoading(true);
-        apiService
-            .get<CookingEvent[]>("/events", { Authorization: `Bearer ${token}` })
-            .then(setEvents)
-            .catch(console.error)
-            .finally(() => setLoading(false));
+
+        let cancelled = false;
+        let isFirst = true;
+
+        const fetchEvents = () => {
+            if (isFirst) setLoading(true);
+            apiService
+                .get<CookingEvent[]>("/events", { Authorization: `Bearer ${token}` })
+                .then((data) => { if (!cancelled) setEvents(data); })
+                .catch(console.error)
+                .finally(() => {
+                    if (isFirst && !cancelled) setLoading(false);
+                    isFirst = false;
+                });
+        };
+
+        fetchEvents();
+        const interval = setInterval(fetchEvents, REFRESH_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
     }, [token]);
 
     if (loading) {

--- a/app/hooks/useEvents.ts
+++ b/app/hooks/useEvents.ts
@@ -9,6 +9,7 @@ type Event = {
   participants?: { id: number }[];
 };
 
+const REFRESH_MS = 15_000;
 
 export const useEvents = () => {
   const api = useApi();
@@ -24,27 +25,28 @@ export const useEvents = () => {
 
   useEffect(() => {
     if (!token) return;
+    let cancelled = false;
 
     const fetchEvents = async () => {
       try {
-        console.log("TOKEN USED FOR EVENTS:", token);
-
         const response = await api.get("/events", {
-          
-            Authorization: `Bearer ${token}`,
-          
+          Authorization: `Bearer ${token}`,
         });
-
-        console.log("EVENTS RESPONSE:", response);
-
-        setEvents(Array.isArray(response) ? response : []);
+        if (!cancelled) {
+          setEvents(Array.isArray(response) ? response : []);
+        }
       } catch (error) {
         console.error("Failed to fetch events", error);
-        setEvents([]);
+        if (!cancelled) setEvents([]);
       }
     };
 
     fetchEvents();
+    const interval = setInterval(fetchEvents, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [api, token]);
 
   return events;

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Card, ConfigProvider, Table } from "antd";
+import type { TableProps } from "antd";
+import Sidebar, { UserAvatar, Header } from "@/components/appLayout";
+import { useApi } from "@/hooks/useApi";
+import { LeaderboardEntry } from "@/types/badge";
+import { BadgeChip } from "@/components/Badge";
+import { Box } from "@mui/material";
+
+const REFRESH_MS = 30_000;
+
+const LeaderboardPage: React.FC = () => {
+  const router = useRouter();
+  const apiService = useApi();
+  const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("token");
+    if (stored) setToken(stored.replace(/"/g, ""));
+  }, []);
+
+  const fetchLeaderboard = useCallback(async () => {
+    if (!token) return;
+    try {
+      const data = await apiService.get<LeaderboardEntry[]>("/leaderboard", {
+        Authorization: `Bearer ${token}`,
+      });
+      setEntries(data);
+    } catch (err) {
+      console.error("Failed to fetch leaderboard", err);
+    }
+  }, [apiService, token]);
+
+  useEffect(() => {
+    fetchLeaderboard();
+    if (!token) return;
+    const intervalId = setInterval(fetchLeaderboard, REFRESH_MS);
+    return () => clearInterval(intervalId);
+  }, [fetchLeaderboard, token]);
+
+  const columns: TableProps<LeaderboardEntry>["columns"] = [
+    {
+      title: "#",
+      dataIndex: "rank",
+      key: "rank",
+      width: 60,
+      render: (rank: number) => {
+        const medal = rank === 1 ? "🥇" : rank === 2 ? "🥈" : rank === 3 ? "🥉" : null;
+        return (
+          <span style={{ fontWeight: 600 }}>
+            {medal ? `${medal} ${rank}` : rank}
+          </span>
+        );
+      },
+    },
+    {
+      title: "User",
+      key: "user",
+      render: (_value, row) => (
+        <Box sx={{ display: "flex", flexDirection: "column" }}>
+          <span style={{ fontWeight: 600 }}>{row.name || row.username}</span>
+          <span style={{ color: "#888", fontSize: 12 }}>@{row.username}</span>
+        </Box>
+      ),
+    },
+    {
+      title: "Badge",
+      key: "badge",
+      render: (_value, row) => (
+        <BadgeChip
+          emoji={row.currentBadgeEmoji}
+          name={row.currentBadgeName}
+          current
+          size="small"
+        />
+      ),
+    },
+    {
+      title: "Wins",
+      dataIndex: "wins",
+      key: "wins",
+      width: 80,
+      align: "right",
+    },
+  ];
+
+  return (
+    <div style={{ display: "flex", minHeight: "100vh", background: "#f5f5f5" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Header title="Leaderboard" rightContent={<UserAvatar />} />
+        <div style={{ padding: 24 }}>
+          {/* ConfigProvider overrides global dark-theme tokens
+              from app/layout.tsx such that table reads as light/white */}
+          <ConfigProvider
+            theme={{
+              token: {
+                colorText: "#1a1a1a",
+                colorBgContainer: "#ffffff",
+              },
+            }}
+          >
+            <Card
+              title="Top cooks"
+              loading={!entries}
+              style={{ borderRadius: 20, border: "1px solid #e8e8e8", background: "#fff" }}
+              styles={{ header: { color: "#1a1a1a" }, body: { background: "#fff" } }}
+            >
+              {entries && (
+                <Table<LeaderboardEntry>
+                  columns={columns}
+                  dataSource={entries}
+                  rowKey="userId"
+                  pagination={false}
+                  onRow={(row) => ({
+                    onClick: () => router.push(`/users/${row.userId}`),
+                    style: { cursor: "pointer" },
+                  })}
+                />
+              )}
+            </Card>
+          </ConfigProvider>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LeaderboardPage;

--- a/app/types/badge.ts
+++ b/app/types/badge.ts
@@ -1,0 +1,20 @@
+export interface Badge {
+  code: string;
+  displayName: string;
+  emoji: string;
+  description: string;
+  requiredWins: number;
+  unlocked: boolean;
+  current: boolean;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: number;
+  username: string;
+  name: string;
+  wins: number;
+  currentBadgeCode: string;
+  currentBadgeName: string;
+  currentBadgeEmoji: string;
+}

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -3,9 +3,12 @@ import React, { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import { User } from "@/types/user";
+import { Badge } from "@/types/badge";
+import { BadgeChip, BadgeShowcase } from "@/components/Badge";
 import { getInitials as computeInitials } from "@/utils/getInitials";
-import { Avatar, Box, Button, Card, CircularProgress, Stack, TextField, Dialog, DialogTitle, DialogContent, DialogActions, IconButton } from "@mui/material";
+import { Avatar, Box, Button, Card, CircularProgress, Divider, Stack, TextField, Dialog, DialogTitle, DialogContent, DialogActions, IconButton } from "@mui/material";
 import EditIcon from '@mui/icons-material/Edit';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Form, message } from "antd";
 
 const Profile: React.FC = () => {
@@ -15,12 +18,17 @@ const Profile: React.FC = () => {
 
   const apiService = useApi();
   const [user, setUser] = useState<User | null>(null);
+  const [badges, setBadges] = useState<Badge[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [nameInput, setNameInput] = useState<string>("");
   const [usernameInput, setUsernameInput] = useState<string>("");
   const [form] = Form.useForm();
+  const ownProfile = typeof window !== "undefined"
+    && userId !== undefined
+    && localStorage.getItem("userId") === userId;
+  const dominantBadge = badges.find((b) => b.current);
 
   type PasswordForm = {
     currentPassword: string;
@@ -40,14 +48,20 @@ const Profile: React.FC = () => {
     const fetchUser = async () => {
       try {
         const storedToken = localStorage.getItem("token") ?? "";
-        console.log("Stored token:", storedToken);
         const headers = { Authorization: `Bearer ${storedToken}` };
-        console.log("Headers for API call:", headers);
         const fetched = await apiService.get<User>(`/users/${userId}`, headers);
-        console.log("Fetched user:", fetched);
         setUser(fetched);
         setNameInput(fetched?.name ?? "");
         setUsernameInput(fetched?.username ?? "");
+
+        // badges are public so we fetch them for any profile we can view
+        try {
+          const fetchedBadges = await apiService.get<Badge[]>(`/users/${userId}/badges`, headers);
+          setBadges(fetchedBadges ?? []);
+        } catch (badgeErr) {
+          console.error("Failed to fetch badges", badgeErr);
+          setBadges([]);
+        }
       } catch (err: unknown) {
         // check for 401 and redirect to previous page
         const e = err as ApiError;
@@ -157,6 +171,11 @@ const Profile: React.FC = () => {
   return (
     <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
       <Card sx={{ width: 520, p: 4, boxShadow: "none", borderRadius: "20px" }}>
+        <Box sx={{ display: "flex", justifyContent: "flex-start", mb: 1 }}>
+          <IconButton aria-label="back" onClick={() => router.back()} sx={{ color: "#4b6624" }}>
+            <ArrowBackIcon />
+          </IconButton>
+        </Box>
         <Stack spacing={2} sx={{ width: "100%" }}>
           <Stack
             direction={{ xs: "column", sm: "row" }}
@@ -171,40 +190,62 @@ const Profile: React.FC = () => {
             </Box>
 
             <Box sx={{ display: "flex", flexDirection: "column", alignItems: { xs: "center", sm: "flex-start" }, flexGrow: 1 }}>
-              <h2 style={{ margin: 0 }}>{user?.name || "Unknown user"}</h2>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: "wrap" }}>
+                <h2 style={{ margin: 0 }}>{user?.name || "Unknown user"}</h2>
+                {dominantBadge && (
+                  <BadgeChip
+                    emoji={dominantBadge.emoji}
+                    name={dominantBadge.displayName}
+                    description={ownProfile ? dominantBadge.description : undefined}
+                    current
+                  />
+                )}
+              </Stack>
               <span style={{ marginTop: 4 }}>@{user?.username || "-"}</span>
             </Box>
 
-            <Box sx={{ display: "flex", justifyContent: { xs: "center", sm: "flex-end" } }}>
-              <IconButton aria-label="edit" onClick={() => setIsEditModalOpen(true)} sx={{ color: "#4b6624" }}>
-                <EditIcon />
-              </IconButton>
-            </Box>
+            {ownProfile && (
+              <Box sx={{ display: "flex", justifyContent: { xs: "center", sm: "flex-end" } }}>
+                <IconButton aria-label="edit" onClick={() => setIsEditModalOpen(true)} sx={{ color: "#4b6624" }}>
+                  <EditIcon />
+                </IconButton>
+              </Box>
+            )}
           </Stack>
         </Stack>
-        <Box sx={{ width: "100%", mt: 2 }}>
-          <Stack direction="row" spacing={2} justifyContent="flex-end" style={{ marginTop: 24 }}>
-            <Button
-              variant="text"
-              onClick={handleLogout}
-              sx={{
-                color: "red",
-                borderRadius: "999px",
-              }}>
-              Logout
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => setIsModalOpen(true)}
-              sx={{
-                borderColor: "#4b6624",
-                color: "#4b6624",
-                borderRadius: "999px",
-              }}>
-              Change password
-            </Button>
-          </Stack>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Box sx={{ width: "100%" }}>
+          <h3 style={{ margin: "0 0 12px 0", color: "#485F23" }}>Badges</h3>
+          <BadgeShowcase badges={badges} showDescriptions={ownProfile} />
         </Box>
+
+        {ownProfile && (
+          <Box sx={{ width: "100%", mt: 2 }}>
+            <Stack direction="row" spacing={2} justifyContent="flex-end" style={{ marginTop: 24 }}>
+              <Button
+                variant="text"
+                onClick={handleLogout}
+                sx={{
+                  color: "red",
+                  borderRadius: "999px",
+                }}>
+                Logout
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => setIsModalOpen(true)}
+                sx={{
+                  borderColor: "#4b6624",
+                  color: "#4b6624",
+                  borderRadius: "999px",
+                }}>
+                Change password
+              </Button>
+            </Stack>
+          </Box>
+        )}
 
         <Dialog
           open={isEditModalOpen}


### PR DESCRIPTION
Adds the badge UI on the client side: badges on the profile page, a leaderboard page, and auto-refresh so new events from other users appear without a manual reload.

closes #18, #9, #11, #12, #78